### PR TITLE
Fix checks for empty or missing entries in JSON

### DIFF
--- a/lib/huginn_epic_store_new_free_game_agent/epic_store_new_free_game_agent.rb
+++ b/lib/huginn_epic_store_new_free_game_agent/epic_store_new_free_game_agent.rb
@@ -213,15 +213,17 @@ module Agents
 
       payload = JSON.parse(response.body)
       payload['data']['Catalog']['searchStore']['elements'].each do |item|
-        if !item['promotions']['promotionalOffers'].blank?
-          start_date = item['promotions']['promotionalOffers'][0]['promotionalOffers'][0]['startDate']
-          end_date = item['promotions']['promotionalOffers'][0]['promotionalOffers'][0]['endDate']
-#          puts start_date
-#          puts end_date
-#          puts Time.parse(start_date).to_i
-#          puts Time.parse(end_date).to_i
-          if Time.now.to_i.between?(Time.parse(start_date).to_i, Time.parse(end_date).to_i)
-            create_event payload: item
+        if !item['promotions']['promotionalOffers'].nil?
+          if !item['promotions']['promotionalOffers'].empty?
+            start_date = item['promotions']['promotionalOffers'][0]['promotionalOffers'][0]['startDate']
+            end_date = item['promotions']['promotionalOffers'][0]['promotionalOffers'][0]['endDate']
+  #          puts start_date
+  #          puts end_date
+  #          puts Time.parse(start_date).to_i
+  #          puts Time.parse(end_date).to_i
+            if Time.now.to_i.between?(Time.parse(start_date).to_i, Time.parse(end_date).to_i)
+              create_event payload: item
+            end
           end
         end
       end

--- a/lib/huginn_epic_store_new_free_game_agent/epic_store_new_free_game_agent.rb
+++ b/lib/huginn_epic_store_new_free_game_agent/epic_store_new_free_game_agent.rb
@@ -213,16 +213,18 @@ module Agents
 
       payload = JSON.parse(response.body)
       payload['data']['Catalog']['searchStore']['elements'].each do |item|
-        if !item['promotions']['promotionalOffers'].nil?
-          if !item['promotions']['promotionalOffers'].empty?
-            start_date = item['promotions']['promotionalOffers'][0]['promotionalOffers'][0]['startDate']
-            end_date = item['promotions']['promotionalOffers'][0]['promotionalOffers'][0]['endDate']
-  #          puts start_date
-  #          puts end_date
-  #          puts Time.parse(start_date).to_i
-  #          puts Time.parse(end_date).to_i
-            if Time.now.to_i.between?(Time.parse(start_date).to_i, Time.parse(end_date).to_i)
-              create_event payload: item
+        if !item['promotions'].nil?
+          if !item['promotions']['promotionalOffers'].nil?
+            if !item['promotions']['promotionalOffers'].empty?
+              start_date = item['promotions']['promotionalOffers'][0]['promotionalOffers'][0]['startDate']
+              end_date = item['promotions']['promotionalOffers'][0]['promotionalOffers'][0]['endDate']
+    #          puts start_date
+    #          puts end_date
+    #          puts Time.parse(start_date).to_i
+    #          puts Time.parse(end_date).to_i
+              if Time.now.to_i.between?(Time.parse(start_date).to_i, Time.parse(end_date).to_i)
+                create_event payload: item
+              end
             end
           end
         end

--- a/lib/huginn_epic_store_new_free_game_agent/epic_store_new_free_game_agent.rb
+++ b/lib/huginn_epic_store_new_free_game_agent/epic_store_new_free_game_agent.rb
@@ -213,7 +213,7 @@ module Agents
 
       payload = JSON.parse(response.body)
       payload['data']['Catalog']['searchStore']['elements'].each do |item|
-        if !item['promotions']['promotionalOffers'].empty?
+        if !item['promotions']['promotionalOffers'].blank?
           start_date = item['promotions']['promotionalOffers'][0]['promotionalOffers'][0]['startDate']
           end_date = item['promotions']['promotionalOffers'][0]['promotionalOffers'][0]['endDate']
 #          puts start_date


### PR DESCRIPTION
epic has started delivering JSON with missing entries sometimes, this was crashing the agent. Added a few more layers of checks of nil to avoid crashes.